### PR TITLE
Mark 'turbs_e' and 'p_col' parameter value simulation as experimental

### DIFF
--- a/R/simulate_parameters.R
+++ b/R/simulate_parameters.R
@@ -7,7 +7,10 @@
 #' probability distributions to apply (`distributions`), and the number of samples to 
 #' generate (`n`), returning a simulated `model_input` object that can be supplied to [run_model()].
 #' 
-#' Simulation is currently only supported for the parameters `flux`, `turbs_e`, and `p_col`. 
+#' We currently recommend to only simulate `flux` values. Simulating `turbs_e` and `p_col` values
+#' is considered \strong{EXPERIMENTAL} at this stage; they are available for exploratory analysis
+#' but should \emph{not} be used in formal studies.
+#' 
 #' The normal, Poisson, negative binomial, and beta distributions are implemented, 
 #' but not all distributions are available for every parameter. See the \strong{Parameters} 
 #' section for details on which distributions can be used with each parameter.
@@ -19,7 +22,8 @@
 #' @param simulation_input A dataframe containing input parameters for the simulation. Parameters to 
 #' simulate should have the following column names: `<par>_mean` and `<par>_sd`, where `<par>` is the name
 #' of the parameter to simulate. 
-#' @param parameters A string vector of parameters to simulate. Valid options are: `flux`, `turbs_e` or `p_col`.
+#' @param parameters A string vector of parameters to simulate. Valid options are: `flux`, 
+#' `turbs_e` (\strong{EXPERIMENTAL}) or `p_col` (\strong{EXPERIMENTAL}).
 #' @param distributions A string vector of probability distributions to use for generating random samples of a 
 #' parameter. Valid options are: `normal`, `poisson`, `nbinom` and `beta`.
 #' @param n The number of random samples to generate.

--- a/R/simulate_parameters.R
+++ b/R/simulate_parameters.R
@@ -103,11 +103,18 @@ simulate_parameters <- function(simulation_input, parameters, distributions, n =
     "turb_dist", "turb_dist_ref", "turbs_e", "turbs_e_ref", "p_col"
   )
 
+  # Mark experimental parameters
+  experimental_pars <- c("turbs_e", "p_col")
+
   sample_methods <- get_sample_methods() # Get sampling dispatch
   cols_to_remove_rename <- get_cols_remove_rename(parameters)   # Determine columns to remove/rename
 
   # Perform checks on parameters
   for (parameter in parameters) {
+
+    if (parameter %in% experimental_pars) {
+      warning(paste0("Simulating values for '", parameter, "' is experimental and should not be used in formal studies."))
+    }
 
     if (!parameter %in% names(allowed_distributions)) {
       stop(paste("The following parameter cannot be simulated:", parameter))

--- a/man/simulate_parameters.Rd
+++ b/man/simulate_parameters.Rd
@@ -11,7 +11,8 @@ simulate_parameters(simulation_input, parameters, distributions, n = 1000)
 simulate should have the following column names: \verb{<par>_mean} and \verb{<par>_sd}, where \verb{<par>} is the name
 of the parameter to simulate.}
 
-\item{parameters}{A string vector of parameters to simulate. Valid options are: \code{flux}, \code{turbs_e} or \code{p_col}.}
+\item{parameters}{A string vector of parameters to simulate. Valid options are: \code{flux},
+\code{turbs_e} (\strong{EXPERIMENTAL}) or \code{p_col} (\strong{EXPERIMENTAL}).}
 
 \item{distributions}{A string vector of probability distributions to use for generating random samples of a
 parameter. Valid options are: \code{normal}, \code{poisson}, \code{nbinom} and \code{beta}.}
@@ -28,7 +29,10 @@ probability distributions. The function uses a dataframe of parameter values
 probability distributions to apply (\code{distributions}), and the number of samples to
 generate (\code{n}), returning a simulated \code{model_input} object that can be supplied to \code{\link[=run_model]{run_model()}}.
 
-Simulation is currently only supported for the parameters \code{flux}, \code{turbs_e}, and \code{p_col}.
+We currently recommend to only simulate \code{flux} values. Simulating \code{turbs_e} and \code{p_col} values
+is considered \strong{EXPERIMENTAL} at this stage; they are available for exploratory analysis
+but should \emph{not} be used in formal studies.
+
 The normal, Poisson, negative binomial, and beta distributions are implemented,
 but not all distributions are available for every parameter. See the \strong{Parameters}
 section for details on which distributions can be used with each parameter.

--- a/tests/testthat/test_simulate_parameters.R
+++ b/tests/testthat/test_simulate_parameters.R
@@ -25,15 +25,18 @@ test_df <- data.frame(
 
 test_that("simulate_parameters runs without errors", {
 
-  parameters <- c("flux", "turbs_e", "p_col")
-  distributions <- c("poisson", "poisson", "beta")
+  parameters <- "flux"
+  distributions <- "poisson"
   n_sims <- 10
 
   # Should run without errors
-  res <- expect_no_error(simulate_parameters(simulation_input = test_df,
-                                             parameters = parameters,
-                                             distributions = distributions,
-                                             n = n_sims))
+  res <- expect_no_error(
+    simulate_parameters(
+      simulation_input = test_df,
+      parameters = parameters,
+      distributions = distributions,
+      n = n_sims
+    ))
 
   # Check whether the correct columns are returned
   exp_cols <- c("species",
@@ -51,6 +54,32 @@ test_that("simulate_parameters runs without errors", {
   # Number of rows should be equal to nrows test_df times n_sims
   exp_nrows <- nrow(test_df) * n_sims
   expect_equal(nrow(res), exp_nrows)
+
+})
+
+
+test_that("simulate_parameters throws the expected warnings when simulating experimental parameters", {
+
+  parameters <- c("turbs_e", "p_col")
+  distributions <- c("poisson", "beta")
+  n_sims <- 10
+
+  # Should throw two warnings, which we'll capture and test
+  wrns <- capture_warnings(
+    simulate_parameters(
+      simulation_input = test_df,
+      parameters = parameters,
+      distributions = distributions,
+      n = n_sims
+    )
+  )
+
+  # Check whether two warnings are thrown
+  expect_length(wrns, 2)
+
+  # Check warning messages
+  expect_match(wrns[1], "Simulating values for 'turbs_e' is experimental and should not be used in formal studies.")
+  expect_match(wrns[2], "Simulating values for 'p_col' is experimental and should not be used in formal studies.")
 
 })
 
@@ -94,10 +123,15 @@ test_that("simulate_parameters runs without errors when using a subset of parame
   # Result should contain a column `flux_samples`
   expect_true("flux" %in% names(res))
 
-  # Try another but with two parameters
-  res_two_pars <- expect_no_error(simulate_parameters(simulation_input = test_df, parameters = c("flux", "p_col"),
-                                                      distributions = c("poisson", "beta"),
-                                                      n = 10))
+  # Try another but with two parameters, which should also throw a warning about 'p_col' being experimental
+  res_two_pars <- expect_warning(
+    simulate_parameters(
+      simulation_input = test_df, 
+      parameters = c("flux", "p_col"),
+      distributions = c("poisson", "beta"),
+      n = 10
+    ), "Simulating values for 'p_col' is experimental and should not be used in formal studies."
+  )
 
   # Result should contain two columns: `flux_samples` and `p_col_samples`
   expect_true("flux" %in% names(res_two_pars))
@@ -153,7 +187,7 @@ test_that("calling check_na_cols on simulation input containing NAs correctly re
 
 
 test_that("simulate_parameters correctly returns a `model_input` object", {
-  parameters <- c("flux", "turbs_e")
-  distributions <- c("nbinom", "poisson")
+  parameters <- "flux"
+  distributions <- "nbinom"
   expect_true(inherits(simulate_parameters(test_df, parameters, distributions), "model_input"))
 })


### PR DESCRIPTION
This pull request explicitly marks simulating values for `turbs_e` and `p_col` parameters with the `simulate_parameters` function as experimental. This pull request resolves issue #9.

**Key changes**

- Simulating `turbs_e` and `p_col` parameter values is listed as experimental in the function documentation of `simulate_parameters`.
- Prints a warning message to the user when `turbs_e` and/or `p_col` are specified in the `parameters` argument of the `simulate_parameters` function. 