### PR TITLE
Add missing R CMD check badge and update installation instructions

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -31,24 +31,18 @@ Flux Collision Model, which allows for modelling uncertainty in parameter estima
 
 ## Installation
 
-You can install the development version of sfcm from [GitHub](https://github.com/jvdz-aw/sfcm) with:
+You can install the development version from [GitHub](https://github.com/jvdz-aw/sfcm) with `pak`:
 
 ```{r eval = FALSE}
 # install.packages("pak")
 pak::pak("jvdz-aw/sfcm")
 ```
 
-Or using:
+Or using `devtools`:
 
 ```{r eval = FALSE}
 # install.packages("devtools")
 devtools::install_github("jvdz-aw/sfcm")
-```
-
-Alternatively, you can download the binary version you prefer and install it with:
-
-```{r eval = FALSE}
-install.packages("sfcm_0.1.0.tar.gz")
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -24,26 +24,19 @@ allows for modelling uncertainty in parameter estimates via simulation.
 
 ## Installation
 
-You can install the development version of sfcm from
-[GitHub](https://github.com/jvdz-aw/sfcm) with:
+You can install the development version from
+[GitHub](https://github.com/jvdz-aw/sfcm) with `pak`:
 
 ``` r
 # install.packages("pak")
 pak::pak("jvdz-aw/sfcm")
 ```
 
-Or using:
+Or using `devtools`:
 
 ``` r
 # install.packages("devtools")
 devtools::install_github("jvdz-aw/sfcm")
-```
-
-Alternatively, you can download the binary version you prefer and
-install it with:
-
-``` r
-install.packages("sfcm_0.1.0.tar.gz")
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![R-CMD-check](https://github.com/jvdz-aw/sfcm/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/jvdz-aw/sfcm/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of **sfcm** is to provide tools for estimating bird collisions


### PR DESCRIPTION
**Description**
This PR adds an `R CMD check` badge to `README.md` and some adjustements to the text in the installation section.

The `R CMD check` badge was already present in `README.Rmd` but missing from the rendered `README.md` because `devtools::build_readme()` hadn't been run.

**Changes**
- Installation Section: Refined small textual adjustments for clarity.
- Badges: Re-rendered `README.md` using `devtools::build_readme()` to properly include the missing `R CMD check` status badge.

**Verification checklist**
- [x] Check `README.md` renders correctly on GitHub with the new badge and text updates.